### PR TITLE
Port to Minecraft 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.14-SNAPSHOT'
 	id 'maven-publish'
 }
 
 def javaVersion = JavaVersion.toVersion(project.java_version)
 
-archivesBaseName = project.archives_base_name
+base.archivesName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
@@ -49,7 +49,7 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
+		rename { "${it}_${project.archives_base_name}"}
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,9 @@ org.gradle.jvmargs=-Xmx4G
 java_version=21
 
 # Fabric Properties
-minecraft_version = 1.21.1
-yarn_mappings=1.21.1+build.3
-loader_version=0.16.5
+minecraft_version = 1.21.11
+yarn_mappings=1.21.11+build.3
+loader_version=0.19.2
 
 # Mod Properties
 mod_version = 1.0.0
@@ -15,4 +15,4 @@ maven_group = net.alfonsormadrid
 archives_base_name = enchant-transfer-mod
 
 # Dependencies
-fabric_version=0.102.0+1.21.1
+fabric_version=0.141.4+1.21.11

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'

--- a/src/main/java/net/alfonsormadrid/enchanttransfer/EnchantTransferMod.java
+++ b/src/main/java/net/alfonsormadrid/enchanttransfer/EnchantTransferMod.java
@@ -8,7 +8,10 @@ import net.alfonsormadrid.enchanttransfer.screens.transfertable.TransferTableScr
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+import net.minecraft.block.Block;
 import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
@@ -24,7 +27,16 @@ public class EnchantTransferMod implements ModInitializer {
 	public static final String MOD_ID = "enchanttransfer";
 	public static final Identifier TRANSFER_TABLE_BLOCK_IDENTIFIER = Identifier.of(MOD_ID, "transfer_table_block");
 
-	public static final TransferTableBlock TRANSFER_TABLE_BLOCK = new TransferTableBlock();
+	public static final RegistryKey<Block> TRANSFER_TABLE_BLOCK_KEY =
+			RegistryKey.of(RegistryKeys.BLOCK, TRANSFER_TABLE_BLOCK_IDENTIFIER);
+	public static final RegistryKey<Item> TRANSFER_TABLE_ITEM_KEY =
+			RegistryKey.of(RegistryKeys.ITEM, TRANSFER_TABLE_BLOCK_IDENTIFIER);
+	public static final RegistryKey<Item> MAGIC_CARD_ITEM_KEY =
+			RegistryKey.of(RegistryKeys.ITEM, Identifier.of(MOD_ID, "magic_card_item"));
+	public static final RegistryKey<BlockEntityType<?>> TRANSFER_TABLE_BLOCK_ENTITY_KEY =
+			RegistryKey.of(RegistryKeys.BLOCK_ENTITY_TYPE, TRANSFER_TABLE_BLOCK_IDENTIFIER);
+
+	public static final TransferTableBlock TRANSFER_TABLE_BLOCK = new TransferTableBlock(TRANSFER_TABLE_BLOCK_KEY);
 
 	public static final RegistryKey<ItemGroup> ITEM_GROUP_KEY =
 			RegistryKey.of(RegistryKeys.ITEM_GROUP, Identifier.of(MOD_ID, "general"));
@@ -33,11 +45,11 @@ public class EnchantTransferMod implements ModInitializer {
 			Registry.register(Registries.SCREEN_HANDLER, TRANSFER_TABLE_BLOCK_IDENTIFIER,
 					new ScreenHandlerType<TransferTableScreenHandler>((syncId, inv) -> new TransferTableScreenHandler(syncId, inv), FeatureFlags.VANILLA_FEATURES));
 
-	public static final TransferTableItem TRANSFER_TABLE_ITEM = new TransferTableItem(TRANSFER_TABLE_BLOCK);
+	public static final TransferTableItem TRANSFER_TABLE_ITEM = new TransferTableItem(TRANSFER_TABLE_BLOCK, TRANSFER_TABLE_ITEM_KEY);
 	public static BlockEntityType<TransferTableBlockEntity> TRANSFER_TABLE_BLOCK_ENTITY =
-			BlockEntityType.Builder.create(TransferTableBlockEntity::new, TRANSFER_TABLE_BLOCK).build();
+			FabricBlockEntityTypeBuilder.create(TransferTableBlockEntity::new, TRANSFER_TABLE_BLOCK).build();
 
-	public static final MagicCardItem MAGIC_CARD_ITEM = new MagicCardItem();
+	public static final MagicCardItem MAGIC_CARD_ITEM = new MagicCardItem(MAGIC_CARD_ITEM_KEY);
 
 	@Override
 	public void onInitialize() {

--- a/src/main/java/net/alfonsormadrid/enchanttransfer/blocks/transfertable/TransferTableBlock.java
+++ b/src/main/java/net/alfonsormadrid/enchanttransfer/blocks/transfertable/TransferTableBlock.java
@@ -3,12 +3,12 @@ package net.alfonsormadrid.enchanttransfer.blocks.transfertable;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.screen.NamedScreenHandlerFactory;
-import net.minecraft.screen.ScreenHandler;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.BlockSoundGroup;
 import net.minecraft.sound.SoundEvents;
@@ -26,9 +26,10 @@ public class TransferTableBlock extends BlockWithEntity {
 
     public static final MapCodec<TransferTableBlock> CODEC = createCodec(TransferTableBlock::new);
 
-    public TransferTableBlock() {
+    public TransferTableBlock(RegistryKey<Block> registryKey) {
         this(
             AbstractBlock.Settings.copy(Blocks.CHEST)
+                .registryKey(registryKey)
                 .sounds(
                     new BlockSoundGroup(
                         5.0F,
@@ -56,8 +57,7 @@ public class TransferTableBlock extends BlockWithEntity {
 
     @Override
     public void onPlaced(World world, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack itemStack) {
-        if (!world.isClient) {
-            ServerWorld serverWorld = (ServerWorld) world;
+        if (world instanceof ServerWorld serverWorld) {
             Vec3d center = Vec3d.ofCenter(pos);
             serverWorld.spawnParticles(ParticleTypes.ELECTRIC_SPARK,
                     center.x, center.y + 0.5, center.z, 40, 0.45, 0.45, 0.45, 0.25);
@@ -67,16 +67,13 @@ public class TransferTableBlock extends BlockWithEntity {
     }
 
     @Override
-    public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
-        if (!newState.isOf(this) && !world.isClient) {
-            ServerWorld serverWorld = (ServerWorld) world;
-            Vec3d center = Vec3d.ofCenter(pos);
-            serverWorld.spawnParticles(ParticleTypes.TOTEM_OF_UNDYING,
-                    center.x, center.y + 0.5, center.z, 25, 0.4, 0.4, 0.4, 0.3);
-            serverWorld.spawnParticles(ParticleTypes.REVERSE_PORTAL,
-                    center.x, center.y + 0.5, center.z, 50, 0.5, 0.5, 0.5, 0.6);
-        }
-        super.onStateReplaced(state, world, pos, newState, moved);
+    public void onStateReplaced(BlockState state, ServerWorld world, BlockPos pos, boolean moved) {
+        Vec3d center = Vec3d.ofCenter(pos);
+        world.spawnParticles(ParticleTypes.TOTEM_OF_UNDYING,
+                center.x, center.y + 0.5, center.z, 25, 0.4, 0.4, 0.4, 0.3);
+        world.spawnParticles(ParticleTypes.REVERSE_PORTAL,
+                center.x, center.y + 0.5, center.z, 50, 0.5, 0.5, 0.5, 0.6);
+        super.onStateReplaced(state, world, pos, moved);
     }
 
     @Override
@@ -91,7 +88,7 @@ public class TransferTableBlock extends BlockWithEntity {
 
     @Override
     public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
-        if (world.isClient) {
+        if (!(world instanceof ServerWorld)) {
             return ActionResult.SUCCESS;
         } else {
             NamedScreenHandlerFactory namedScreenHandlerFactory = this.createScreenHandlerFactory(state, world, pos);
@@ -108,13 +105,4 @@ public class TransferTableBlock extends BlockWithEntity {
         return Stats.CUSTOM.getOrCreateStat(Stats.OPEN_CHEST);
     }
 
-    @Override
-    public boolean hasComparatorOutput(BlockState state) {
-        return true;
-    }
-
-    @Override
-    public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
-        return ScreenHandler.calculateComparatorOutput(world.getBlockEntity(pos));
-    }
 }

--- a/src/main/java/net/alfonsormadrid/enchanttransfer/blocks/transfertable/TransferTableItem.java
+++ b/src/main/java/net/alfonsormadrid/enchanttransfer/blocks/transfertable/TransferTableItem.java
@@ -2,12 +2,13 @@ package net.alfonsormadrid.enchanttransfer.blocks.transfertable;
 
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
+import net.minecraft.registry.RegistryKey;
 
 public class TransferTableItem extends BlockItem {
-    public TransferTableItem(TransferTableBlock transferTableBlock) {
+    public TransferTableItem(TransferTableBlock transferTableBlock, RegistryKey<Item> registryKey) {
         super(
             transferTableBlock,
-            new Item.Settings().fireproof()
+            new Item.Settings().registryKey(registryKey).fireproof()
         );
     }
 }

--- a/src/main/java/net/alfonsormadrid/enchanttransfer/item/MagicCardItem.java
+++ b/src/main/java/net/alfonsormadrid/enchanttransfer/item/MagicCardItem.java
@@ -2,29 +2,20 @@ package net.alfonsormadrid.enchanttransfer.item;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 
 public class MagicCardItem extends Item {
-    public MagicCardItem() {
-        super(new Item.Settings().fireproof());
+    public MagicCardItem(RegistryKey<Item> registryKey) {
+        super(new Item.Settings().registryKey(registryKey).fireproof());
     }
 
     @Override
-    public TypedActionResult<ItemStack> use(World world, PlayerEntity playerEntity, Hand hand) {
+    public ActionResult use(World world, PlayerEntity playerEntity, Hand hand) {
         playerEntity.playSound(SoundEvents.ENTITY_LIGHTNING_BOLT_THUNDER, 1.0F, 1.0F);
-        return TypedActionResult.success(playerEntity.getOffHandStack());
-    }
-
-    @Override
-    public boolean isEnchantable(ItemStack stack) {
-        if (stack.getEnchantments().isEmpty()) {
-            return super.isEnchantable(stack);
-        } else {
-            return false;
-        }
+        return ActionResult.SUCCESS;
     }
 }

--- a/src/main/java/net/alfonsormadrid/enchanttransfer/screens/transfertable/TransferTableScreen.java
+++ b/src/main/java/net/alfonsormadrid/enchanttransfer/screens/transfertable/TransferTableScreen.java
@@ -3,6 +3,7 @@ package net.alfonsormadrid.enchanttransfer.screens.transfertable;
 import net.alfonsormadrid.enchanttransfer.EnchantTransferMod;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -18,7 +19,7 @@ public class TransferTableScreen extends HandledScreen<TransferTableScreenHandle
     protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
         int x = (width - backgroundWidth) / 2;
         int y = (height - backgroundHeight) / 2;
-        context.drawTexture(TEXTURE, x, y, 0, 0, backgroundWidth, backgroundHeight);
+        context.drawTexture(RenderPipelines.GUI_TEXTURED, TEXTURE, x, y, 0.0f, 0.0f, backgroundWidth, backgroundHeight, 256, 256);
     }
 
     @Override

--- a/src/main/resources/assets/enchanttransfer/items/magic_card_item.json
+++ b/src/main/resources/assets/enchanttransfer/items/magic_card_item.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "enchanttransfer:item/magic_card_item"
+  }
+}

--- a/src/main/resources/assets/enchanttransfer/items/transfer_table_block.json
+++ b/src/main/resources/assets/enchanttransfer/items/transfer_table_block.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "enchanttransfer:block/transfer_table_block"
+  }
+}


### PR DESCRIPTION
- Update Fabric Loom to 1.14, Gradle to 9.2.0, Fabric API to 0.141.4+1.21.11
- Add RegistryKey to block, item and block entity settings (1.21.4+ requirement)
- Fix TransferTableBlock API changes: onStateReplaced new signature, world.isClient replaced with instanceof ServerWorld, remove comparator output methods
- Fix MagicCardItem.use() return type changed to ActionResult
- Fix BlockEntityType creation using FabricBlockEntityTypeBuilder
- Fix DrawContext.drawTexture to use RenderPipelines with explicit pipeline
- Add items/ folder with new 1.21.4+ item model format
- Replace jcenter() with mavenCentral() and archivesBaseName with base.archivesName